### PR TITLE
Fix thread being blocked after unexpected connection loss

### DIFF
--- a/src/commonMain/kotlin/com/jessecorbett/diskord/api/websocket/DiscordWebSocket.kt
+++ b/src/commonMain/kotlin/com/jessecorbett/diskord/api/websocket/DiscordWebSocket.kt
@@ -99,64 +99,66 @@ class DiscordWebSocket(
         isOpen = true
 
         logger.trace { "Attempting a websocket connection" }
-        socketClient.wss(host = url, port = 443, request = {
-            logger.trace { "Building socket HttpRequest" }
-        }) {
-            logger.info { "Starting socket connection" }
+        try {
+            socketClient.wss(host = url, port = 443, request = {
+                logger.trace { "Building socket HttpRequest" }
+            }) {
+                logger.info { "Starting socket connection" }
 
-            sendWebsocketMessage = this::send
-            stop = { code, reason -> close(CloseReason(code.code, reason)) }
+                sendWebsocketMessage = this::send
+                stop = { code, reason -> close(CloseReason(code.code, reason)) }
 
-            launch {
-                val closeReason = this@wss.closeReason.await()
-                if (closeReason == null) {
-                    logger.warn { "Closed with no close reason, probably a connection issue" }
-                } else {
-                    val closeCode = WebSocketCloseCode.values().find { it.code == closeReason.code }
-                    val message = if (closeReason.message.isEmpty()) {
-                        "Closed with code '$closeCode' with no reason provided"
+                launch {
+                    val closeReason = this@wss.closeReason.await()
+                    if (closeReason == null) {
+                        logger.warn { "Closed with no close reason, probably a connection issue" }
                     } else {
-                        "Closed with code '$closeCode' for reason '${closeReason.message}'"
+                        val closeCode = WebSocketCloseCode.values().find { it.code == closeReason.code }
+                        val message = if (closeReason.message.isEmpty()) {
+                            "Closed with code '$closeCode' with no reason provided"
+                        } else {
+                            "Closed with code '$closeCode' for reason '${closeReason.message}'"
+                        }
+                        logger.warn { message }
                     }
-                    logger.warn { message }
                 }
+
+                logger.info { "Starting incoming loop" }
+
+                while (!incoming.isClosedForReceive) {
+                    val message = try {
+                        incoming.receive()
+                    } catch (e: ClosedReceiveChannelException) {
+                        logger.warn { "Receive channel is closed" }
+                        break
+                    }
+
+                    logger.trace { "Incoming Message:\n${message.data.toHexDump()}" }
+
+                    when (message) {
+                        is Frame.Text -> {
+                            val text = message.readText()
+                            receiveMessage(Json.nonstrict.parse(GatewayMessage.serializer(), text))
+                        }
+                        is Frame.Binary -> {
+                            TODO("Add support for binary formatted data")
+                        }
+                        is Frame.Close -> {
+                            logger.info { "Closing with message: $message" }
+                        }
+                        is Frame.Ping, is Frame.Pong -> {
+                            // Not used
+                            logger.debug { message }
+                        }
+                    }
+                }
+                logger.info { "Exited the incoming loop" }
+
             }
-
-            logger.info { "Starting incoming loop" }
-
-            while (!incoming.isClosedForReceive) {
-                val message = try {
-                    incoming.receive()
-                } catch (e: ClosedReceiveChannelException) {
-                    logger.warn { "Receive channel is closed" }
-                    break
-                }
-
-                logger.trace { "Incoming Message:\n${message.data.toHexDump()}" }
-
-                when (message) {
-                    is Frame.Text -> {
-                        val text = message.readText()
-                        receiveMessage(Json.nonstrict.parse(GatewayMessage.serializer(), text))
-                    }
-                    is Frame.Binary -> {
-                        TODO("Add support for binary formatted data")
-                    }
-                    is Frame.Close -> {
-                        logger.info { "Closing with message: $message" }
-                    }
-                    is Frame.Ping, is Frame.Pong -> {
-                        // Not used
-                        logger.debug { message }
-                    }
-                }
-            }
-            logger.info { "Exited the incoming loop" }
-
+        } finally {
+            isOpen = false
+            logger.info { "Socket connection has closed" }
         }
-
-        isOpen = false
-        logger.info { "Socket connection has closed" }
     }
 
     /**
@@ -187,7 +189,10 @@ class DiscordWebSocket(
         heartbeatJob?.cancel()
         heartbeatJob = null
         stop(WebSocketCloseCode.NORMAL_CLOSURE, "Requested close")
-        while (isOpen) {} // Block until the connection is confirmed closed, handling race conditions
+        // Block until the connection is confirmed closed, handling race conditions
+        while (isOpen) {
+            delay(100)
+        }
         logger.info { "Closed connection" }
     }
 


### PR DESCRIPTION
- Always ensure connection is marked as closed when websocket is disconnected
- Add sleep/suspension point in busy wait (decreases wasted CPU when busy waiting and prevents the entire thread from being blocked if the busy wait never completes)


Just had this come up in prod where the websocket disconnected and a thread got perpetually stuck in the `while(isOpen)` loop. This was probably caused by the Discord outage today (https://status.discordapp.com/incidents/vs0q8cvycg46).