### PR TITLE
Bugfix/add update global command interactionbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The library is packaged into two artifacts.
 
 ## How do I use this?
 
-[Dokka documentation](https://jesselcorbett.gitlab.io/diskord/)
+[Dokka documentation](https://diskord.gitlab.io/diskord/)
 
 For an example project you can easily clone to get started, look at the [diskord-starter repo.](https://gitlab.com/diskord/diskord-starter)
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The library is packaged into two artifacts.
 
 [Dokka documentation](https://jesselcorbett.gitlab.io/diskord/)
 
-For an example project you can easily clone to get started, look at the [diskord-starter repo.](https://gitlab.com/incendium/diskord-starter)
+For an example project you can easily clone to get started, look at the [diskord-starter repo.](https://gitlab.com/diskord/diskord-starter)
 
-There are also a collection of examples in the [diskord-examples repo.](https://gitlab.com/incendium/diskord-examples)
+There are also a collection of examples in the [diskord-examples repo.](https://gitlab.com/diskord/diskord-examples)
 
 ### Simple Example
 

--- a/diskord-bot/src/commonMain/kotlin/com/jessecorbett/diskord/bot/interaction/InteractionBuilder.kt
+++ b/diskord-bot/src/commonMain/kotlin/com/jessecorbett/diskord/bot/interaction/InteractionBuilder.kt
@@ -84,10 +84,17 @@ public class InteractionBuilder(
         dispatcher.onReady {
             builder.block()
             val commandWithParams = createCommand.copy(options = builder.parameters.map { CommandOption.fromOption(it) })
-            command = if (guildId != null) {
-                botContext.command(applicationId).createGuildCommand(guildId, commandWithParams)
-            } else {
-                botContext.command(applicationId).createGlobalCommand(commandWithParams)
+			botContext.command(applicationId).getGlobalCommands().forEach { gc ->
+                command = if (guildId != null) {
+                    botContext.command(applicationId).createGuildCommand(guildId, commandWithParams)
+                } else if (gc.name == createCommand.name) {
+                    botContext.command(applicationId).updateGlobalCommand(
+                        gc.id,
+                        PatchCommand(gc.name, gc.description, gc.options, gc.defaultPermission)
+                    )
+                } else {
+                    botContext.command(applicationId).createGlobalCommand(commandWithParams)
+                }
             }
         }
 

--- a/diskord-core/build.gradle.kts
+++ b/diskord-core/build.gradle.kts
@@ -76,6 +76,14 @@ kotlin {
         }
     }
 
+    macosX64("mac") {
+        binaries.executable()
+    }
+
+    mingwX64("win") {
+        binaries.executable()
+    }
+
     metadata {
         mavenPublication {
             artifact(javadocJar)
@@ -138,9 +146,16 @@ kotlin {
                 implementation("io.ktor:ktor-client-js:$ktorVersion")
             }
         }
-        val jsTest by getting {
+
+        val macMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test-js:$kotlinVersion")
+                implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+            }
+        }
+
+        val winMain by getting {
+            dependencies {
+                implementation("io.ktor:ktor-client-winhttp:$ktorVersion")
             }
         }
     }

--- a/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/api/channel/ChannelClient.kt
+++ b/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/api/channel/ChannelClient.kt
@@ -22,7 +22,6 @@ import com.jessecorbett.diskord.api.common.Webhook
 import com.jessecorbett.diskord.api.common.stringified
 import com.jessecorbett.diskord.api.gateway.model.GatewayIntent
 import com.jessecorbett.diskord.internal.client.RestClient
-import com.jessecorbett.diskord.internal.urlEncode
 import com.jessecorbett.diskord.util.DiskordInternals
 import com.jessecorbett.diskord.util.defaultJson
 import com.jessecorbett.diskord.util.isThread
@@ -398,7 +397,7 @@ public class ChannelClient(public val channelId: String, client: RestClient) : R
     public suspend fun addMessageReaction(messageId: String, emojiText: String) {
         PUT(
             "/channels/$channelId/messages/$messageId/reactions",
-            "/${urlEncode(emojiText)}/@me",
+            "/$emojiText/@me",
             rateKey = "/channels/$channelId/messages/messageId/reactions"
         ).body<Unit>()
     }
@@ -429,7 +428,7 @@ public class ChannelClient(public val channelId: String, client: RestClient) : R
     public suspend fun removeMessageReaction(messageId: String, emojiText: String, userId: String = "@me") {
         DELETE(
             "/channels/$channelId/messages/$messageId/reactions",
-            "/${urlEncode(emojiText)}/$userId",
+            "/$emojiText/$userId",
             rateKey = "/channels/$channelId/messages/messageId/reactions"
         ).body<Unit>()
     }
@@ -461,7 +460,7 @@ public class ChannelClient(public val channelId: String, client: RestClient) : R
     public suspend fun getMessageReactions(messageId: String, textEmoji: String): List<User> {
         return GET(
             "/channels/$channelId/messages/$messageId/reactions",
-            "/${urlEncode(textEmoji)}",
+            "/$textEmoji",
             rateKey = "/channels/$channelId/messages/messageId/reactions"
         ).body()
     }
@@ -504,7 +503,7 @@ public class ChannelClient(public val channelId: String, client: RestClient) : R
     public suspend fun deleteAllMessageReactions(messageId: String, textEmoji: String) {
         DELETE(
             "/channels/$channelId/messages/$messageId/reactions",
-            "/${urlEncode(textEmoji)}",
+            "/$textEmoji",
             rateKey = "/channels/$channelId/messages/messageId/reactions"
         ).body<Unit>()
     }

--- a/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
+++ b/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
@@ -4,7 +4,7 @@ import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
 
 internal const val defaultUserAgentUrl = "https://gitlab.com/jesselcorbett/diskord"
-internal const val defaultUserAgentVersion = "2.1.4"
+internal const val defaultUserAgentVersion = "3.0.2"
 
 internal expect fun websocketClient(): HttpClientEngineFactory<HttpClientEngineConfig>
 internal expect fun httpClient(): HttpClientEngineFactory<HttpClientEngineConfig>

--- a/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
+++ b/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
@@ -1,3 +1,0 @@
-package com.jessecorbett.diskord.internal
-
-internal expect fun urlEncode(input: String): String

--- a/diskord-core/src/jsMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
+++ b/diskord-core/src/jsMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
@@ -1,5 +1,0 @@
-package com.jessecorbett.diskord.internal
-
-internal external fun encodeURIComponent(uri: String): String
-
-internal actual fun urlEncode(input: String): String = encodeURIComponent(input)

--- a/diskord-core/src/jvmMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
+++ b/diskord-core/src/jvmMain/kotlin/com/jessecorbett/diskord/internal/URLEncoding.kt
@@ -1,5 +1,0 @@
-package com.jessecorbett.diskord.internal
-
-import java.net.URLEncoder
-
-internal actual fun urlEncode(input: String): String = URLEncoder.encode(input, "UTF-8")

--- a/diskord-core/src/macMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
+++ b/diskord-core/src/macMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
@@ -1,0 +1,8 @@
+package com.jessecorbett.diskord.internal
+
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.darwin.Darwin
+
+internal actual fun websocketClient(): HttpClientEngineFactory<HttpClientEngineConfig> = Darwin
+internal actual fun httpClient(): HttpClientEngineFactory<HttpClientEngineConfig> = Darwin

--- a/diskord-core/src/winMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
+++ b/diskord-core/src/winMain/kotlin/com/jessecorbett/diskord/internal/CommonResources.kt
@@ -1,0 +1,8 @@
+package com.jessecorbett.diskord.internal
+
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.winhttp.WinHttp
+
+internal actual fun websocketClient(): HttpClientEngineFactory<HttpClientEngineConfig> = WinHttp
+internal actual fun httpClient(): HttpClientEngineFactory<HttpClientEngineConfig> = WinHttp

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx512M
 
-diskordVersion=3.0.1
+diskordVersion=3.0.2-SNAPSHOT
 
 kotlinVersion=1.7.21
 kotlinxCoroutinesVersion=1.6.4


### PR DESCRIPTION
The issue with Discords API is that whenever a global command exists, it will randomly throw an error saying it's already created and crash the bot. 

Solution: pull all global commands then loop through each of them to check against the command being created. If it's there, to use a PATCH vs POST. (createGuildCommand vs updateGlobalCommand).

Let me know if there's a better way.