### PR TITLE
Allow ActionRow components in responses

### DIFF
--- a/diskord-bot/src/commonMain/kotlin/com/jessecorbett/diskord/bot/interaction/ResponseContext.kt
+++ b/diskord-bot/src/commonMain/kotlin/com/jessecorbett/diskord/bot/interaction/ResponseContext.kt
@@ -4,11 +4,9 @@ import com.jessecorbett.diskord.api.channel.AllowedMentions
 import com.jessecorbett.diskord.api.channel.Embed
 import com.jessecorbett.diskord.api.common.ActionRow
 import com.jessecorbett.diskord.api.common.Attachment
+import com.jessecorbett.diskord.api.common.MessageComponent
 import com.jessecorbett.diskord.api.common.TextInput
-import com.jessecorbett.diskord.api.interaction.CommandInteractionDataResolved
-import com.jessecorbett.diskord.api.interaction.CommandInteractionOptionResponse
-import com.jessecorbett.diskord.api.interaction.Interaction
-import com.jessecorbett.diskord.api.interaction.ModalSubmit
+import com.jessecorbett.diskord.api.interaction.*
 import com.jessecorbett.diskord.api.interaction.callback.*
 import com.jessecorbett.diskord.api.webhook.CreateWebhookMessage
 import com.jessecorbett.diskord.bot.BotContext
@@ -88,7 +86,7 @@ public data class ResponseContext<I: Interaction> internal constructor(
                     embeds = response.data.embeds,
                     allowedMentions = response.data.allowedMentions ?: AllowedMentions.NONE,
                     flags = response.data.flags,
-                    components = emptyList(), // TODO: resolve conflict
+                    components = response.data.components
                 ),
                 true
             )
@@ -112,11 +110,12 @@ public data class ResponseContext<I: Interaction> internal constructor(
     public class ResponseBuilder {
         public var content: String? = null
         public var tts: Boolean = false
-        public var embeds: MutableList<Embed> = mutableListOf()
+        public var embeds: List<Embed> = mutableListOf()
         public var allowedMentions: AllowedMentions? = null
         public var flags: InteractionCommandCallbackDataFlags = InteractionCommandCallbackDataFlags.NONE
         // TODO: components
-        public var attachments: MutableList<Attachment> = mutableListOf()
+        public var attachments: List<Attachment> = mutableListOf()
+        public var components: List<ActionRow> = mutableListOf()
 
         /**
          * Marks the message as ephemeral, so only the invoking user can see it
@@ -143,7 +142,7 @@ public data class ResponseContext<I: Interaction> internal constructor(
                 embeds = embeds,
                 allowedMentions = allowedMentions,
                 flags = flags,
-                components = emptyList(),
+                components = components,
                 attachments = attachments
             )
         )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "Diskord"
+rootProject.name = "diskord"
 
 include(":diskord-core")
 include(":diskord-bot")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "diskord"
+rootProject.name = "Diskord"
 
 include(":diskord-core")
 include(":diskord-bot")


### PR DESCRIPTION
Before you needed to send an entirely different message, but still required response to not break
```kt
this.respond {
    this.content = "something"
    ephemeral
}
this@callback.channel(channelArg ?: config.devChannelId ?: "").let { channel ->
    val message = channel.sendMessage(changelog, components = listOf(
        ActionRow(Button(url = uploadedFile.attachments.first().url, label = "Download", style = ButtonStyle.Link))
    ))
    channel.getPinnedMessages().forEach { channel.unpinMessage(it.id) }
    channel.pinMessage(message.id)
}
command.deleteOriginalResponse()
```
Now it can just go in the response
```kt
this.respond {
    this.content = changelog
    this.components = listOf(ActionRow(Button(url = uploadedFile.attachments.first().url, label = "Download", style = ButtonStyle.Link)))
    ephemeral
}
this@callback.channel(channelArg ?: config.devChannelId ?: "").let { channel ->
    channel.getPinnedMessages().forEach { channel.unpinMessage(it.id) }
    channel.pinMessage(command.client.getOriginalInteractionResponse().id)
}
```